### PR TITLE
CMenuSpinControl: Fixed crash getting current string with no active model

### DIFF
--- a/controls/SpinControl.cpp
+++ b/controls/SpinControl.cpp
@@ -312,6 +312,11 @@ void CMenuSpinControl::SetCurrentValue( const char *stringValue )
 {
 	ASSERT( m_pModel );
 
+	if ( !m_pModel )
+	{
+		return;
+	}
+
 	int i = 0;
 
 	for( ; i <= (int)m_flMaxValue; i++ )

--- a/controls/SpinControl.h
+++ b/controls/SpinControl.h
@@ -43,7 +43,7 @@ public:
 	void SetCurrentValue( float curValue );
 
 	float GetCurrentValue( ) { return m_flCurValue; }
-	const char *GetCurrentString( ) { return m_pModel->GetText( (int)m_flCurValue ); }
+	const char *GetCurrentString( ) { return m_pModel ? m_pModel->GetText( (int)m_flCurValue ) : NULL; }
 
 	void ForceDisplayString( const char *display );
 


### PR DESCRIPTION
This could happen by going to Multiplayer -> Customize -> Game options.