### PR TITLE
Add gamepad button mappings

### DIFF
--- a/controls/ItemsHolder.cpp
+++ b/controls/ItemsHolder.cpp
@@ -102,8 +102,10 @@ bool CMenuItemsHolder::Key( const int key, const bool down )
 		{
 		case K_UPARROW:
 		case K_KP_UPARROW:
+		case K_DPAD_UP:
 		case K_LEFTARROW:
 		case K_KP_LEFTARROW:
+		case K_DPAD_LEFT:
 			cursorPrev = m_iCursorPrev = m_iCursor;
 
 			m_iCursor--;
@@ -126,8 +128,10 @@ bool CMenuItemsHolder::Key( const int key, const bool down )
 			break;
 		case K_DOWNARROW:
 		case K_KP_DOWNARROW:
+		case K_DPAD_DOWN:
 		case K_RIGHTARROW:
 		case K_KP_RIGHTARROW:
+		case K_DPAD_RIGHT:
 		case K_TAB:
 			cursorPrev = m_iCursorPrev = m_iCursor;
 			m_iCursor++;

--- a/controls/ScrollView.cpp
+++ b/controls/ScrollView.cpp
@@ -37,17 +37,21 @@ bool CMenuScrollView::KeyDown( int key )
 		{
 		case K_MWHEELUP:
 		case K_UPARROW:
+		case K_DPAD_UP:
 			newPos -= 20;
 			break;
 		case K_MWHEELDOWN:
 		case K_DOWNARROW:
+		case K_DPAD_DOWN:
 			newPos += 20;
 			break;
 
 		case K_PGUP:
+		case K_L1_BUTTON:
 			newPos -= 100;
 			break;
 		case K_PGDN:
+		case K_R1_BUTTON:
 			newPos += 100;
 			break;
 		case K_MOUSE1:

--- a/controls/Table.cpp
+++ b/controls/Table.cpp
@@ -350,19 +350,23 @@ bool CMenuTable::KeyDown( int key )
 		break;
 	case K_PGDN:
 	case K_KP_PGDN:
+	case K_R1_BUTTON:
 		sound = MoveCursor( 2 ) ? uiSoundMove : uiSoundBuzz;
 		break;
 	case K_PGUP:
 	case K_KP_PGUP:
+	case K_L1_BUTTON:
 		sound = MoveCursor( -2 ) ? uiSoundMove : uiSoundBuzz;
 		break;
 	case K_UPARROW:
 	case K_KP_UPARROW:
+	case K_DPAD_UP:
 	case K_MWHEELUP:
 		sound = MoveCursor( -1 ) ? uiSoundMove : uiSoundBuzz;
 		break;
 	case K_DOWNARROW:
 	case K_KP_DOWNARROW:
+	case K_DPAD_DOWN:
 	case K_MWHEELDOWN:
 		sound = MoveCursor( 1 ) ? uiSoundMove : uiSoundBuzz;
 		break;


### PR DESCRIPTION
Should be merged after https://github.com/FWGS/xash3d-fwgs/pull/275, which adds `K_DPAD_UP/DOWN/LEFT/RIGHT` to xash3d-fwgs