### PR TITLE
Table: initialize iNumRows to 0 (fixes #37)

### DIFF
--- a/controls/Table.cpp
+++ b/controls/Table.cpp
@@ -31,7 +31,7 @@ CMenuTable::CMenuTable() : BaseClass(),
 	szDownArrow( UI_DOWNARROW ), szDownArrowFocus( UI_DOWNARROWFOCUS ), szDownArrowPressed( UI_DOWNARROWPRESSED ),
 	iTopItem( 0 ),
 	iScrollBarSliding( false ),
-	iHighlight( -1 ), iCurItem( 0 ),
+	iHighlight( -1 ), iCurItem( 0 ), iNumRows( 0 ),
 	m_iLastItemMouseChange( 0 ),
 	m_iSortingColumn( -1 ),
 	m_pModel( NULL )


### PR DESCRIPTION
Previously `iNumRows` was left uninitialized after creation and until `VidInit`, leading to #37 and possibly other issues, where [this check](https://github.com/FWGS/mainui_cpp/blob/master/controls/Table.cpp#L161) would sometimes incorrectly pass because of the garbage in `iNumRows` and cause the scroll to screw up.