### PR TITLE
controls: Field: Make SetBuffer calls SetCvarString

### DIFF
--- a/controls/Field.h
+++ b/controls/Field.h
@@ -48,6 +48,7 @@ public:
 		Q_strncpy( szBuffer, buffer, UI_MAX_FIELD_LINE );
 		iCursor = strlen( szBuffer );
 		iScroll = g_FontMgr->CutText( font, szBuffer, m_scChSize, iRealWidth, true );
+		SetCvarString( szBuffer );
 	}
 
 	const char *GetBuffer()


### PR DESCRIPTION
When `SetBuffer` is called, it only sets the internal value buffer, without setting the cvar value.
Other events, `Char` and `KeyDown` call `SetCvarString` because they made sure that the value has changed.
One example of this bug is the handling of `maxplayers` cvar in `CreateGame` page.
This caused some issues, for instance FWGS/xash3d-fwgs#425. You can verify this by creating a new game WITHOUT touching the `maxplayers` field. After the map has finished loading, open console and check the current value of `maxplayers`. It will not be `16`, but will be `''`. When `changelevel` is called, the game will be set to single player mode because `SV_SetupClients` will use this empty value.