### PR TITLE
BaseMenu: fallback to new sound paths if WON-style ones are not found

### DIFF
--- a/BaseMenu.cpp
+++ b/BaseMenu.cpp
@@ -40,23 +40,27 @@ cvar_t		*ui_language;
 uiStatic_t	uiStatic;
 static CMenuEntry	*s_pEntries = NULL;
 
+const char	*uiSoundOldPrefix	= "media/";
+const char	*uiSoundNewPrefix	= "sound/common/";
+const char	*uiSounds[] = {
 #ifdef CS16CLIENT
-const char	*uiSoundIn			= "";
-const char	*uiSoundOut         = "";
-const char	*uiSoundLaunch      = "sound/UI/buttonclickrelease.wav";
-const char	*uiSoundRollOver	= "sound/UI/buttonrollover.wav";
+	"",
+	"",
+	"sound/UI/buttonclickrelease.wav",
+	"sound/UI/buttonrollover.wav",
 #else
-const char	*uiSoundIn			= "media/launch_upmenu1.wav";
-const char	*uiSoundOut			= "media/launch_dnmenu1.wav";
-const char	*uiSoundLaunch		= "media/launch_select2.wav";
-const char	*uiSoundRollOver	= "";
+	"media/launch_upmenu1.wav",
+	"media/launch_dnmenu1.wav",
+	"media/launch_select2.wav",
+	"",
 #endif
-const char	*uiSoundGlow        = "media/launch_glow1.wav";
-const char	*uiSoundBuzz        = "media/launch_deny2.wav";
-const char	*uiSoundKey         = "media/launch_select1.wav";
-const char	*uiSoundRemoveKey   = "media/launch_deny1.wav";
-const char	*uiSoundMove        = "";		// Xash3D not use movesound
-const char	*uiSoundNull        = "";
+	"media/launch_glow1.wav",
+	"media/launch_deny2.wav",
+	"media/launch_select1.wav",
+	"media/launch_deny1.wav",
+	"",
+	""
+};
 
 // they match default WON colors.lst now, except alpha
 unsigned int		uiColorHelp         = 0xFF7F7F7F;	// 127, 127, 127, 255	// hint letters color
@@ -686,7 +690,7 @@ void UI_UpdateMenu( float flTime )
 	// drawn, to avoid delay while caching images
 	if( uiStatic.enterSound > 0.0f && uiStatic.enterSound <= gpGlobals->time )
 	{
-		EngFuncs::PlayLocalSound( uiSoundIn );
+		EngFuncs::PlayLocalSound( uiStatic.sounds[SND_IN] );
 		uiStatic.enterSound = -1;
 	}
 
@@ -991,7 +995,29 @@ static void UI_LoadBackgroundMapList( void )
 	EngFuncs::COM_FreeFile( afile );
 }
 
+static void UI_LoadSounds( void )
+{
+	memset( uiStatic.sounds, 0, sizeof( uiStatic.sounds ) );
 
+	if ( uiStatic.lowmemory )
+		return;
+
+	for ( int i = 0; i < SND_COUNT; i++ )
+	{
+		if ( !uiSounds[i] || *uiSounds[i] == '\0' )
+			continue;
+
+		if ( !EngFuncs::FileExists( uiSounds[i] ) )
+		{
+			size_t len = strlen( uiSoundOldPrefix );
+
+			if ( !strncmp( uiSounds[i], uiSoundOldPrefix, len ) )
+				sprintf( uiStatic.sounds[i], "%s%s", uiSoundNewPrefix, uiSounds[i] + len );
+		}
+		else
+			strcpy( uiStatic.sounds[i], uiSounds[i] );
+	}
+}
 
 /*
 =================
@@ -1046,6 +1072,9 @@ int UI_VidInit( void )
 
 	// VidInit FontManager
 	g_FontMgr->VidInit();
+
+	// load button sounds
+	UI_LoadSounds();
 
 	uiStatic.menu.VidInit( calledOnce );
 

--- a/BaseMenu.cpp
+++ b/BaseMenu.cpp
@@ -1012,10 +1012,10 @@ static void UI_LoadSounds( void )
 			size_t len = strlen( uiSoundOldPrefix );
 
 			if ( !strncmp( uiSounds[i], uiSoundOldPrefix, len ) )
-				sprintf( uiStatic.sounds[i], "%s%s", uiSoundNewPrefix, uiSounds[i] + len );
+				snprintf( uiStatic.sounds[i], sizeof( uiStatic.sounds[i] ), "%s%s", uiSoundNewPrefix, uiSounds[i] + len );
 		}
 		else
-			strcpy( uiStatic.sounds[i], uiSounds[i] );
+			Q_strncpy( uiStatic.sounds[i], uiSounds[i], sizeof( uiStatic.sounds[i] ) );
 	}
 }
 

--- a/BaseMenu.h
+++ b/BaseMenu.h
@@ -77,6 +77,21 @@ extern cvar_t   *ui_show_window_stack;
 extern cvar_t	*ui_borderclip;
 extern cvar_t	*ui_language;
 
+enum EUISounds
+{
+	SND_IN = 0,
+	SND_OUT,
+	SND_LAUNCH,
+	SND_ROLLOVER,
+	SND_GLOW,
+	SND_BUZZ,
+	SND_KEY,
+	SND_REMOVEKEY,
+	SND_MOVE,
+	SND_NULL,
+	SND_COUNT
+};
+
 typedef struct
 {
 	CWindowStack menu;
@@ -131,6 +146,8 @@ typedef struct
 	bool renderPicbuttonText;
 
 	int lowmemory;
+
+	char sounds[SND_COUNT][32];
 } uiStatic_t;
 
 extern float	cursorDY;			// use for touch scroll
@@ -138,17 +155,6 @@ extern bool g_bCursorDown;
 extern uiStatic_t		uiStatic;
 
 #define DLG_X ((uiStatic.width - 640) / 2 - 192) // Dialogs are 640px in width
-
-extern const char		*uiSoundIn;
-extern const char		*uiSoundRollOver;
-extern const char		*uiSoundOut;
-extern const char		*uiSoundKey;
-extern const char		*uiSoundRemoveKey;
-extern const char		*uiSoundLaunch;
-extern const char		*uiSoundBuzz;
-extern const char		*uiSoundGlow;
-extern const char		*uiSoundMove;
-extern const char		*uiSoundNull;
 
 extern unsigned int	uiColorHelp;
 extern unsigned int	uiPromptBgColor;

--- a/BaseMenu.h
+++ b/BaseMenu.h
@@ -147,7 +147,7 @@ typedef struct
 
 	int lowmemory;
 
-	char sounds[SND_COUNT][32];
+	char sounds[SND_COUNT][40];
 } uiStatic_t;
 
 extern float	cursorDY;			// use for touch scroll

--- a/controls/Action.cpp
+++ b/controls/Action.cpp
@@ -77,9 +77,9 @@ bool CMenuAction::KeyUp( int key )
 	const char *sound = 0;
 
 	if( UI::Key::IsEnter( key ) && !(iFlags & QMF_MOUSEONLY) )
-		sound = uiSoundLaunch;
+		sound = uiStatic.sounds[SND_LAUNCH];
 	else if( UI::Key::IsLeftMouse( key ) && ( iFlags & QMF_HASMOUSEFOCUS ) )
-		sound = uiSoundLaunch;
+		sound = uiStatic.sounds[SND_LAUNCH];
 
 	if( sound )
 	{

--- a/controls/BaseWindow.cpp
+++ b/controls/BaseWindow.cpp
@@ -65,7 +65,7 @@ void CMenuBaseWindow::Hide()
 {
 	if( m_pStack == &uiStatic.menu ) // hack!
 	{
-		EngFuncs::PlayLocalSound( uiSoundOut );
+		EngFuncs::PlayLocalSound( uiStatic.sounds[SND_OUT] );
 	}
 
 	m_pStack->Remove( this );
@@ -98,7 +98,7 @@ bool CMenuBaseWindow::KeyDown( int key )
 	if( UI::Key::IsEscape( key ) )
 	{
 		Hide( );
-		PlayLocalSound( uiSoundOut );
+		PlayLocalSound( uiStatic.sounds[SND_OUT] );
 		return true;
 	}
 

--- a/controls/Bitmap.cpp
+++ b/controls/Bitmap.cpp
@@ -46,9 +46,9 @@ bool CMenuBitmap::KeyUp( int key )
 	const char *sound = 0;
 
 	if( UI::Key::IsEnter( key ) && !(iFlags & QMF_MOUSEONLY) )
-		sound = uiSoundLaunch;
+		sound = uiStatic.sounds[SND_LAUNCH];
 	else if( UI::Key::IsLeftMouse( key ) && ( iFlags & QMF_HASMOUSEFOCUS ) )
-		sound = uiSoundLaunch;
+		sound = uiStatic.sounds[SND_LAUNCH];
 
 	if( sound )
 	{

--- a/controls/CheckBox.cpp
+++ b/controls/CheckBox.cpp
@@ -63,7 +63,7 @@ bool CMenuCheckBox::KeyUp( int key )
 	case K_MOUSE1:
 		if(!( iFlags & QMF_HASMOUSEFOCUS ))
 			break;
-		sound = uiSoundGlow;
+		sound = uiStatic.sounds[SND_GLOW];
 		break;
 	case K_ENTER:
 	case K_KP_ENTER:
@@ -71,7 +71,7 @@ bool CMenuCheckBox::KeyUp( int key )
 		//if( !down ) return sound;
 		if( iFlags & QMF_MOUSEONLY )
 			break;
-		sound = uiSoundGlow;
+		sound = uiStatic.sounds[SND_GLOW];
 		break;
 	}
 
@@ -99,7 +99,7 @@ bool CMenuCheckBox::KeyDown( int key )
 	case K_MOUSE1:
 		if(!( iFlags & QMF_HASMOUSEFOCUS ))
 			break;
-		sound = uiSoundGlow;
+		sound = uiStatic.sounds[SND_GLOW];
 		break;
 	case K_ENTER:
 	case K_KP_ENTER:
@@ -107,7 +107,7 @@ bool CMenuCheckBox::KeyDown( int key )
 		//if( !down ) return sound;
 		if( iFlags & QMF_MOUSEONLY )
 			break;
-		sound = uiSoundGlow;
+		sound = uiStatic.sounds[SND_GLOW];
 		break;
 	}
 

--- a/controls/ItemsHolder.cpp
+++ b/controls/ItemsHolder.cpp
@@ -114,7 +114,7 @@ bool CMenuItemsHolder::Key( const int key, const bool down )
 				if( cursorPrev != m_iCursor )
 				{
 					CursorMoved();
-					m_pItems[m_iCursor]->PlayLocalSound( uiSoundMove );
+					m_pItems[m_iCursor]->PlayLocalSound( uiStatic.sounds[SND_MOVE] );
 					handled = true;
 
 					m_pItems[m_iCursorPrev]->iFlags &= ~QMF_HASKEYBOARDFOCUS;
@@ -140,7 +140,7 @@ bool CMenuItemsHolder::Key( const int key, const bool down )
 				if( cursorPrev != m_iCursor )
 				{
 					CursorMoved();
-					m_pItems[m_iCursor]->PlayLocalSound( uiSoundMove );
+					m_pItems[m_iCursor]->PlayLocalSound( uiStatic.sounds[SND_MOVE] );
 					handled = true;
 
 					m_pItems[m_iCursorPrev]->iFlags &= ~QMF_HASKEYBOARDFOCUS;
@@ -240,7 +240,7 @@ bool CMenuItemsHolder::MouseMove( int x, int y )
 			if( m_iCursorPrev != -1 )
 				m_pItems[m_iCursorPrev]->iFlags &= ~(QMF_HASMOUSEFOCUS|QMF_HASKEYBOARDFOCUS);
 
-			m_pItems[m_iCursor]->PlayLocalSound( uiSoundMove );
+			m_pItems[m_iCursor]->PlayLocalSound( uiStatic.sounds[SND_MOVE] );
 		}
 
 		m_pItems[m_iCursor]->iFlags |= QMF_HASMOUSEFOCUS;

--- a/controls/PicButton.cpp
+++ b/controls/PicButton.cpp
@@ -55,9 +55,9 @@ bool CMenuPicButton::KeyUp( int key )
 	const char *sound = 0;
 
 	if( UI::Key::IsEnter( key ) && !(iFlags & QMF_MOUSEONLY) )
-		sound = uiSoundLaunch;
+		sound = uiStatic.sounds[SND_LAUNCH];
 	else if( UI::Key::IsLeftMouse( key ) && ( iFlags & QMF_HASMOUSEFOCUS ) )
-		sound = uiSoundLaunch;
+		sound = uiStatic.sounds[SND_LAUNCH];
 
 	if( sound )
 	{

--- a/controls/PlayerModelView.cpp
+++ b/controls/PlayerModelView.cpp
@@ -136,7 +136,7 @@ bool CMenuPlayerModelView::KeyDown( int key )
 		return CMenuBaseItem::KeyDown( key );
 	}
 
-	PlayLocalSound( uiSoundLaunch );
+	PlayLocalSound( uiStatic.sounds[SND_LAUNCH] );
 	return false;
 }
 

--- a/controls/Slider.cpp
+++ b/controls/Slider.cpp
@@ -110,7 +110,7 @@ bool CMenuSlider::KeyDown( int key )
 		if( m_flCurValue < m_flMinValue )
 		{
 			m_flCurValue = m_flMinValue;
-			PlayLocalSound( uiSoundBuzz );
+			PlayLocalSound( uiStatic.sounds[SND_BUZZ] );
 			return true;
 		}
 
@@ -118,7 +118,7 @@ bool CMenuSlider::KeyDown( int key )
 		SetCvarValue( m_flCurValue );
 		_Event( QM_CHANGED );
 
-		PlayLocalSound( uiSoundKey );
+		PlayLocalSound( uiStatic.sounds[SND_KEY] );
 		return true;
 	case K_RIGHTARROW:
 		m_flCurValue += m_flRange;
@@ -126,14 +126,14 @@ bool CMenuSlider::KeyDown( int key )
 		if( m_flCurValue > m_flMaxValue )
 		{
 			m_flCurValue = m_flMaxValue;
-			PlayLocalSound( uiSoundBuzz );
+			PlayLocalSound( uiStatic.sounds[SND_BUZZ] );
 			return true;
 		}
 
 		// tell menu about changes
 		SetCvarValue( m_flCurValue );
 		_Event( QM_CHANGED );
-		PlayLocalSound( uiSoundKey );
+		PlayLocalSound( uiStatic.sounds[SND_KEY] );
 		return true;
 	}
 

--- a/controls/SpinControl.cpp
+++ b/controls/SpinControl.cpp
@@ -74,7 +74,7 @@ bool CMenuSpinControl::KeyDown(	int key )
 	if( sound )
 	{
 		_Event( QM_PRESSED );
-		if( sound != uiSoundBuzz )
+		if( sound != uiStatic.sounds[SND_BUZZ] )
 		{
 			Display();
 			_Event( QM_CHANGED );
@@ -126,7 +126,7 @@ bool CMenuSpinControl::KeyUp( int key )
 	if( sound )
 	{
 		_Event( QM_RELEASED );
-		if( sound != uiSoundBuzz )
+		if( sound != uiStatic.sounds[SND_BUZZ] )
 		{
 			Display();
 			_Event( QM_CHANGED );
@@ -251,9 +251,9 @@ const char *CMenuSpinControl::MoveLeft()
 		m_flCurValue -= m_flRange;
 		if( m_flCurValue < m_flMinValue )
 			m_flCurValue = m_flMinValue;
-		sound = uiSoundMove;
+		sound = uiStatic.sounds[SND_MOVE];
 	}
-	else sound = uiSoundBuzz;
+	else sound = uiStatic.sounds[SND_BUZZ];
 
 	return sound;
 }
@@ -267,9 +267,9 @@ const char *CMenuSpinControl::MoveRight()
 		m_flCurValue += m_flRange;
 		if( m_flCurValue > m_flMaxValue )
 			m_flCurValue = m_flMaxValue;
-		sound = uiSoundMove;
+		sound = uiStatic.sounds[SND_MOVE];
 	}
-	else sound = uiSoundBuzz;
+	else sound = uiStatic.sounds[SND_BUZZ];
 
 	return sound;
 }

--- a/controls/Switch.cpp
+++ b/controls/Switch.cpp
@@ -131,7 +131,7 @@ bool CMenuSwitch::KeyUp( int key )
 		state = IsNewStateByMouseClick();
 		haveNewState = state != m_iState;
 		if( haveNewState )
-			sound = uiSoundGlow;
+			sound = uiStatic.sounds[SND_GLOW];
 		break;
 	case K_ENTER:
 	case K_KP_ENTER:
@@ -139,7 +139,7 @@ bool CMenuSwitch::KeyUp( int key )
 	case K_AUX1:
 		if( iFlags & QMF_MOUSEONLY )
 			break;
-		sound = uiSoundGlow;
+		sound = uiStatic.sounds[SND_GLOW];
 		break;
 	}
 
@@ -178,7 +178,7 @@ bool CMenuSwitch::KeyDown( int key )
 	case K_AUX1:
 		if( iFlags & QMF_MOUSEONLY )
 			break;
-		sound = uiSoundGlow;
+		sound = uiStatic.sounds[SND_GLOW];
 		break;
 	}
 

--- a/controls/Table.cpp
+++ b/controls/Table.cpp
@@ -193,14 +193,14 @@ bool CMenuTable::KeyUp( int key )
 		if( UI_CursorInRect( upArrow, arrow ) )
 		{
 			if( MoveView( -5 ) )
-				sound = uiSoundMove;
-			else sound = uiSoundBuzz;
+				sound = uiStatic.sounds[SND_MOVE];
+			else sound = uiStatic.sounds[SND_BUZZ];
 		}
 		else if( UI_CursorInRect( downArrow, arrow ))
 		{
 			if( MoveView( 5 ) )
-				sound = uiSoundMove;
-			else sound = uiSoundBuzz;
+				sound = uiStatic.sounds[SND_MOVE];
+			else sound = uiStatic.sounds[SND_BUZZ];
 		}
 		else if( UI_CursorInRect( boxPos, boxSize ))
 		{
@@ -224,7 +224,7 @@ bool CMenuTable::KeyUp( int key )
 					else
 					{
 						iCurItem = newCur;
-						sound = uiSoundNull;
+						sound = uiStatic.sounds[SND_NULL];
 					}
 
 					m_iLastItemMouseChange = uiStatic.realTime;
@@ -280,7 +280,7 @@ bool CMenuTable::KeyUp( int key )
 
 	if( sound )
 	{
-		if( sound != uiSoundBuzz )
+		if( sound != uiStatic.sounds[SND_BUZZ] )
 			_Event( QM_CHANGED );
 
 		PlayLocalSound( sound );
@@ -336,40 +336,40 @@ bool CMenuTable::KeyDown( int key )
 		if( iCurItem )
 		{
 			iCurItem = 0;
-			sound = uiSoundMove;
+			sound = uiStatic.sounds[SND_MOVE];
 		}
-		else sound = uiSoundBuzz;
+		else sound = uiStatic.sounds[SND_BUZZ];
 		break;
 	case K_END:
 	case K_KP_END:
 		if( iCurItem != m_pModel->GetRows() - 1 )
 		{
 			iCurItem = m_pModel->GetRows() - 1;
-			sound = uiSoundMove;
+			sound = uiStatic.sounds[SND_MOVE];
 		}
-		else sound = uiSoundBuzz;
+		else sound = uiStatic.sounds[SND_BUZZ];
 		break;
 	case K_PGDN:
 	case K_KP_PGDN:
 	case K_R1_BUTTON:
-		sound = MoveCursor( 2 ) ? uiSoundMove : uiSoundBuzz;
+		sound = MoveCursor( 2 ) ? uiStatic.sounds[SND_MOVE] : uiStatic.sounds[SND_BUZZ];
 		break;
 	case K_PGUP:
 	case K_KP_PGUP:
 	case K_L1_BUTTON:
-		sound = MoveCursor( -2 ) ? uiSoundMove : uiSoundBuzz;
+		sound = MoveCursor( -2 ) ? uiStatic.sounds[SND_MOVE] : uiStatic.sounds[SND_BUZZ];
 		break;
 	case K_UPARROW:
 	case K_KP_UPARROW:
 	case K_DPAD_UP:
 	case K_MWHEELUP:
-		sound = MoveCursor( -1 ) ? uiSoundMove : uiSoundBuzz;
+		sound = MoveCursor( -1 ) ? uiStatic.sounds[SND_MOVE] : uiStatic.sounds[SND_BUZZ];
 		break;
 	case K_DOWNARROW:
 	case K_KP_DOWNARROW:
 	case K_DPAD_DOWN:
 	case K_MWHEELDOWN:
-		sound = MoveCursor( 1 ) ? uiSoundMove : uiSoundBuzz;
+		sound = MoveCursor( 1 ) ? uiStatic.sounds[SND_MOVE] : uiStatic.sounds[SND_BUZZ];
 		break;
 	case K_BACKSPACE:
 	case K_DEL:
@@ -392,7 +392,7 @@ bool CMenuTable::KeyDown( int key )
 
 	if( sound )
 	{
-		if( sound != uiSoundBuzz )
+		if( sound != uiStatic.sounds[SND_BUZZ] )
 			_Event( QM_CHANGED );
 
 		PlayLocalSound( sound );

--- a/menus/ConnectionProgress.cpp
+++ b/menus/ConnectionProgress.cpp
@@ -148,11 +148,11 @@ bool CMenuConnectionProgress::KeyDown( int key )
 	{
 	case K_ESCAPE:
 		dialog.Show();
-		PlayLocalSound( uiSoundOut );
+		PlayLocalSound( uiStatic.sounds[SND_OUT] );
 		return true;
 	case '~':
 		consoleButton.onReleased( &consoleButton );
-		PlayLocalSound( uiSoundLaunch );
+		PlayLocalSound( uiStatic.sounds[SND_LAUNCH] );
 		return true;
 	case 'A':
 		HandleDisconnect();

--- a/menus/Controls.cpp
+++ b/menus/Controls.cpp
@@ -307,7 +307,7 @@ bool CMenuControls::CGrabKeyMessageBox::KeyUp( int key )
 	if( key == '`' || key == '~' || key == K_ESCAPE )
 	{
 		Hide();
-		PlayLocalSound( uiSoundBuzz );
+		PlayLocalSound( uiStatic.sounds[SND_BUZZ] );
 		return true;
 	}
 	else
@@ -323,7 +323,7 @@ bool CMenuControls::CGrabKeyMessageBox::KeyUp( int key )
 
 	Hide();
 
-	PlayLocalSound( uiSoundLaunch );
+	PlayLocalSound( uiStatic.sounds[SND_LAUNCH] );
 
 	return true;
 }
@@ -337,14 +337,14 @@ void CMenuControls::UnbindEntry()
 {
 	if( !keysListModel.IsLineUsable( keysList.GetCurrentIndex() ) )
 	{
-		PlayLocalSound( uiSoundBuzz );
+		PlayLocalSound( uiStatic.sounds[SND_BUZZ] );
 		return; // not a key
 	}
 
 	const char *bindName = keysListModel.keysBind[keysList.GetCurrentIndex()];
 
 	UnbindCommand( bindName );
-	PlayLocalSound( uiSoundRemoveKey );
+	PlayLocalSound( uiStatic.sounds[SND_REMOVEKEY] );
 	keysListModel.Update();
 
 	// disabled: left command just unbinded
@@ -355,7 +355,7 @@ void CMenuControls::EnterGrabMode()
 {
 	if( !keysListModel.IsLineUsable( keysList.GetCurrentIndex() ) )
 	{
-		PlayLocalSound( uiSoundBuzz );
+		PlayLocalSound( uiStatic.sounds[SND_BUZZ] );
 		return;
 	}
 
@@ -370,7 +370,7 @@ void CMenuControls::EnterGrabMode()
 
 	msgBox1.Show();
 
-	PlayLocalSound( uiSoundKey );
+	PlayLocalSound( uiStatic.sounds[SND_KEY] );
 }
 
 /*

--- a/menus/TouchEdit.cpp
+++ b/menus/TouchEdit.cpp
@@ -88,7 +88,7 @@ bool CMenuTouchEdit::KeyDown( int key )
 	if( UI::Key::IsEscape( key ) )
 	{
 		Hide();
-		PlayLocalSound( uiSoundOut );
+		PlayLocalSound( uiStatic.sounds[SND_OUT] );
 		return true;
 	}
 	return false;


### PR DESCRIPTION
This allows us to remove these sounds from extras.pak, as they are actually found in the Steam version, but at another location. Also this keeps compatibility with mods which might replace the sounds using "media" folder.