### PR TITLE
BaseMenu: add the media/ prefix to gamestartup background track

### DIFF
--- a/BaseMenu.cpp
+++ b/BaseMenu.cpp
@@ -668,7 +668,7 @@ void UI_UpdateMenu( float flTime )
 		{
 			// if game was launched with commandline e.g. +map or +load ignore the music
 			if( !CL_IsActive( ))
-				EngFuncs::PlayBackgroundTrack( "gamestartup", "gamestartup" );
+				EngFuncs::PlayBackgroundTrack( "media/gamestartup", "media/gamestartup" );
 			first = FALSE;
 		}
 	}


### PR DESCRIPTION
Fixes: https://github.com/FWGS/xash3d-fwgs/issues/1334

Don't forget to update submodule in the engine repository