### PR TITLE
BaseWindow: remove the SND_OUT playback when pressing escape key

### DIFF
--- a/controls/BaseWindow.cpp
+++ b/controls/BaseWindow.cpp
@@ -98,7 +98,6 @@ bool CMenuBaseWindow::KeyDown( int key )
 	if( UI::Key::IsEscape( key ) )
 	{
 		Hide( );
-		PlayLocalSound( uiStatic.sounds[SND_OUT] );
 		return true;
 	}
 


### PR DESCRIPTION
Fixes: https://github.com/FWGS/mainui_cpp/issues/79