### PR TITLE
BaseMenu: fix incorrect drawing of long strings

### DIFF
--- a/BaseMenu.cpp
+++ b/BaseMenu.cpp
@@ -10,7 +10,7 @@ of the License, or (at your option) any later version.
 
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 
 See the GNU General Public License for more details.
 
@@ -304,15 +304,21 @@ int UI_DrawString( HFont font, int x, int y, int w, int h,
 	if( justify & QM_TOP )
 	{
 		yy = y;
+		h -= h % charH;
 	}
 	else if( justify & QM_BOTTOM )
 	{
 		yy = y + h - charH;
+		h -= h % charH;
 	}
 	else
 	{
 		yy = y + (h - charH)/2;
+		h -= charH;
 	}
+
+	if( flags & ETF_NO_WRAP )
+		h = charH;
 
 	int i = 0;
 	int ellipsisWide = g_FontMgr->GetEllipsisWide( font );
@@ -358,7 +364,7 @@ int UI_DrawString( HFont font, int x, int y, int w, int h,
 				int charWide;
 
 				// does we have free space for new line?
-				if( yy < (yy + h ) - charH )
+				if( yy < (y + h) - charH )
 				{
 					if( uch == ' ' && pixelWide < w ) // remember last whitespace
 					{
@@ -381,7 +387,7 @@ int UI_DrawString( HFont font, int x, int y, int w, int h,
 				if( !(flags & ETF_NOSIZELIMIT) && pixelWide + charWide > w )
 				{
 					// do we have free space for new line?
-					if( yy < (yy + h) - charH )
+					if( yy < (y + h) - charH )
 					{
 						// try to word wrap
 						if( save_j != 0 && save_pixelWide != 0 )
@@ -663,7 +669,7 @@ void UI_UpdateMenu( float flTime )
 
 		uiStatic.firstDraw = false;
 		static int first = TRUE;
-                    
+
 		if( first )
 		{
 			// if game was launched with commandline e.g. +map or +load ignore the music
@@ -1026,7 +1032,7 @@ int UI_VidInit( void )
 	if( uiStatic.textInput )
 	{
 		uiStatic.menu.InputMethodResized();
-		
+
 		return 0;
 	}
 	if(!calledOnce) UI_Precache();
@@ -1044,7 +1050,7 @@ int UI_VidInit( void )
 		uiStatic.yOffset = 0;
 	}
 
-	
+
 	uiStatic.width = ScreenWidth / uiStatic.scaleX;
 	// move cursor to screen center
 	uiStatic.cursorX = ScreenWidth / 2;

--- a/BaseMenu.h
+++ b/BaseMenu.h
@@ -1,5 +1,5 @@
 /*
-basemenu.h - menu basic header 
+basemenu.h - menu basic header
 Copyright (C) 2010 Uncle Mike
 
 This program is free software: you can redistribute it and/or modify
@@ -188,7 +188,8 @@ enum ETextFlags
 	ETF_FORCECOL    = BIT( 0 ),
 	ETF_SHADOW      = BIT( 1 ),
 	ETF_NOSIZELIMIT = BIT( 2 ),
-	ETF_ADDITIVE    = BIT( 3 )
+	ETF_ADDITIVE    = BIT( 3 ),
+	ETF_NO_WRAP     = BIT( 4 )
 };
 
 int  UI_DrawString( HFont font, int x, int y, int w, int h, const char *str, const unsigned int col, int charH, uint justify, uint flags = 0 );


### PR DESCRIPTION
Also adds ETF_NO_WRAP to disable text wrapping.
![ps_20231021170427](https://github.com/FWGS/mainui_cpp/assets/2345745/ea675e57-001b-4dff-a8dc-9ff5e484913d) ![ps_20231021170454](https://github.com/FWGS/mainui_cpp/assets/2345745/d9302493-057c-4207-b61b-bb387f3c64fa)

_Updated screenshots_