### PR TITLE
Add sorting to custom game menu

### DIFF
--- a/controls/Table.cpp
+++ b/controls/Table.cpp
@@ -332,6 +332,8 @@ bool CMenuTable::KeyUp( int key )
 						{
 							SwapOrder();
 						}
+
+						_Event( QM_CHANGED );
 					}
 				}
 			}


### PR DESCRIPTION
Fix FWGS/xash3d-fwgs#1641.

I added this line here https://github.com/lorsanta/mainui_cpp/blob/1ad9fb91257c0283cfb439dc80b0f4ebaca46046/controls/Table.cpp#L336, because without it if you click to sort the mods, for example by name in discending order, you may have 'Activate' grayed out because `UpdateExtras()` wasn't called

I didn't add sorting by size and by version. To sort by size I guess I would need to write the opposite of `Q_pretifymem()`, let me know if it something that could be useful.