### PR TITLE
ServerBrowser: avoid duplicating entries in the history list when connecting to the server

### DIFF
--- a/menus/ServerBrowser.cpp
+++ b/menus/ServerBrowser.cpp
@@ -684,12 +684,26 @@ void CMenuServerBrowser::Connect( server_t &server )
 
 	if( menu_internetgames->m_bLanOnly == false )
 	{
-		if( menu_internetgames->historyList.Count() > 20 ) // FIXME: make configurable
-			menu_internetgames->historyList.FastRemove( 0 );
-		menu_internetgames->historyList.AddToTail( favlist_entry_t( sadr, prot, true ) );
+		bool serverExists = false;
+
+		for( int i = 0; i < menu_internetgames->historyList.Count(); ++i )
+		{
+			if( strcmp( menu_internetgames->historyList[i].sadr, sadr ) == 0 && strcmp( menu_internetgames->historyList[i].prot, prot ) == 0 )
+			{
+				serverExists = true;
+				break;
+			}
+		}
+
+		if( !serverExists )
+		{
+			if( menu_internetgames->historyList.Count() > 20 ) // FIXME: make configurable
+				menu_internetgames->historyList.FastRemove( 0 );
+			menu_internetgames->historyList.AddToTail( favlist_entry_t( sadr, prot, true ) );
 
 
-		menu_internetgames->SaveLists();
+			menu_internetgames->SaveLists();
+		}
 	}
 
 	EngFuncs::ClientCmdF( false, "connect \"%s\" \"%s\"\n", sadr, prot );


### PR DESCRIPTION
Fixes: https://github.com/FWGS/mainui_cpp/issues/127