### PR TITLE
TouchButtons: adjust button widths

### DIFF
--- a/menus/TouchButtons.cpp
+++ b/menus/TouchButtons.cpp
@@ -518,8 +518,8 @@ void CMenuTouchButtons::_VidInit()
 	precision.SetCoord( 400, 470 );
 	buttonList.SetRect( 72, 135, 300, 395 );
 
-	save.SetRect( 384 - 42 + 320, 550, 130, 50 );
-	editor.SetRect( 384 - 42 + 320, 600, 130, 50 );
+	save.SetRect( 384 - 42 + 320, 550, 170, 50 );
+	editor.SetRect( 384 - 42 + 320, 600, 170, 50 );
 	select.SetRect( 400 + fields_w - 95, 300, 150,50 );
 
 	name.SetRect( 400, 550, 205, 32 );
@@ -528,8 +528,8 @@ void CMenuTouchButtons::_VidInit()
 	color.SetRect( sliders_x + 120, 360, 70, 50 );
 	preview.SetRect( 400, 300, 70, 70 );
 
-	reset.SetRect( 384 - 72 + 480, 600, 130, 50 );
-	remove.SetRect( 384 - 72 + 480, 550, 130, 50 );
+	reset.SetRect( 384 - 72 + 520, 600, 170, 50 );
+	remove.SetRect( 384 - 72 + 520, 550, 170, 50 );
 }
 
 ADD_MENU3( menu_touchbuttons, CMenuTouchButtons, UI_TouchButtons_Menu );


### PR DESCRIPTION
## Before:
<img width="288" height="132" alt="before1" src="https://github.com/user-attachments/assets/824cd0d7-cf2c-4f64-9798-4539dffcf3ca" />
<img width="339" height="123" alt="before2" src="https://github.com/user-attachments/assets/daac34a2-e058-434c-a507-5859ab75cec9" />
<img width="327" height="122" alt="before3" src="https://github.com/user-attachments/assets/e91909f6-c461-42a0-b8d2-abcba59e117a" />

## After:
<img width="341" height="150" alt="after1" src="https://github.com/user-attachments/assets/cb22c3b6-61e9-4624-8fe4-b4b3a53b6bd6" />
<img width="382" height="120" alt="after2" src="https://github.com/user-attachments/assets/615c8aaa-3d51-4241-a8e8-d037a074ed90" />
<img width="369" height="123" alt="after3" src="https://github.com/user-attachments/assets/13e3fc49-7bcf-4778-a655-680ba978e11e" />

