### PR TITLE
Draw logo.avi only when it's present in the current gamedir and WON background is active

### DIFF
--- a/controls/BackgroundBitmap.cpp
+++ b/controls/BackgroundBitmap.cpp
@@ -333,8 +333,10 @@ void CMenuBackgroundBitmap::UpdatePreference()
 			s_state = DRAW_COLOR;
 	}
 
-	// Prevent logo.avi to be shown on any background type other than won
-	if( s_state != DRAW_WON && s_bEnableLogoMovie )
+	// Enable logo.avi only for WON background, disable otherwise
+	if( s_state == DRAW_WON )
+		s_bEnableLogoMovie = EngFuncs::FileExists( "media/logo.avi", true );
+	else
 		s_bEnableLogoMovie = false;
 
 	ClearBits( ui_prefer_won_background->flags, FCVAR_CHANGED );
@@ -364,9 +366,6 @@ void CMenuBackgroundBitmap::LoadBackground()
 	}
 	else if( LoadWONBackground( false ))
 		Con_DPrintf( "%s: found %s background in %s directory\n", __func__, "won", "base" );
-
-	// logo.avi should be an independent asset from the background image
-	s_bEnableLogoMovie = EngFuncs::FileExists( "media/logo.avi", false );
 
 	UpdatePreference();
 }

--- a/controls/MovieBanner.cpp
+++ b/controls/MovieBanner.cpp
@@ -18,6 +18,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 */
 #include "MovieBanner.h"
+#include "BackgroundBitmap.h"
 
 // In WON menus the background is always 640x480
 const float splashWidth = 640.0f;
@@ -70,6 +71,9 @@ void CMenuMovieBanner::Draw()
 		// Logo needs to be reset when this CVAR changes
 		VidInit();
 	}
+
+	if( !CMenuBackgroundBitmap::ShouldDrawLogoMovie() )
+		return;
 
 	if( EngFuncs::ClientInGame() && EngFuncs::GetCvarFloat( "ui_renderworld" ))
 		return;

--- a/menus/Main.cpp
+++ b/menus/Main.cpp
@@ -273,7 +273,7 @@ void CMenuMain::_Init( void )
 		if( animatedBanner.TryLoad())
 			AddItem( animatedBanner );
 	}
-	else if( CMenuBackgroundBitmap::ShouldDrawLogoMovie( ))
+	else
 	{
 		AddItem( movieBanner );
 	}


### PR DESCRIPTION
Tested the following cases:

1. **Launching with `ui_prefer_won_background 1`**
   - Conditions: `gfx/shell/splash.bmp` and `media/logo.avi` are present in the current gamedir, TGA logo parts from the 25th Anniversary Update are **not present**
   - Result: `logo.avi` is displayed
   - Switching to `ui_prefer_won_background 0` → `logo.avi` disappears

2. **Launching with `ui_prefer_won_background 0`**
   - Conditions: `gfx/shell/splash.bmp` and `media/logo.avi` are present in the current gamedir, TGA logo parts from the 25th Anniversary Update are **not present**
   - Result: `logo.avi` is not displayed
   - Switching to `ui_prefer_won_background 1` → `logo.avi` appears

3. **Launching the game with `ui_prefer_won_background 0` / `ui_prefer_won_background 1` or switching between them during runtime**
   - Conditions: `gfx/shell/splash.bmp` and `media/logo.avi` are present in the current gamedir, TGA logo parts from the 25th Anniversary Update are **present**
   - Result: `logo.avi` is not displayed