### PR TITLE
Fix checkbox and slider resets in Video Options

### DIFF
--- a/controls/Editable.cpp
+++ b/controls/Editable.cpp
@@ -39,7 +39,13 @@ void CMenuEditable::Reload()
 {
 	// editable already initialized, so update
 	if( m_szCvarName )
+	{
 		UpdateCvar( true );
+
+		// Ensure onCvarGet is called for reliable sync
+		if( onCvarGet )
+			onCvarGet( this );
+	}
 }
 
 void CMenuEditable::SetCvarValue( float value )

--- a/menus/VideoOptions.cpp
+++ b/menus/VideoOptions.cpp
@@ -309,7 +309,6 @@ void CMenuVidOptions::_VidInit()
 
 void CMenuVidOptions::Reload()
 {
-	CMenuFramework::Reload();
 	bool gl_active = !strnicmp( EngFuncs::GetCvarString( "r_refdll_loaded" ), "gl", 2 );
 	bool soft_active = !stricmp( EngFuncs::GetCvarString( "r_refdll_loaded" ), "soft" );
 
@@ -381,6 +380,8 @@ void CMenuVidOptions::Reload()
 		filtering.SetGrayed( true );
 		filtering.SetInactive( true );
 	}
+
+	CMenuFramework::Reload();
 }
 
 ADD_MENU( menu_vidoptions, CMenuVidOptions, UI_VidOptions_Menu );


### PR DESCRIPTION
Fix texture filtering checkbox becoming unchecked after engine restart and gamma/brightness sliders resetting on reopening Video Options