### PR TITLE
ScriptMenu: Decouple cvar handling for user and settings scripts

### DIFF
--- a/menus/dynamic/ScriptMenu.cpp
+++ b/menus/dynamic/ScriptMenu.cpp
@@ -55,7 +55,7 @@ public:
 	CMenuScriptConfig();
 	~CMenuScriptConfig() override;
 
-	void SetScriptConfig( const char *path, bool earlyInit = false );
+	void SetScriptConfig( const char *path, bool bIsSettings, bool earlyInit = false );
 
 	void SaveAndPopMenu() override
 	{
@@ -85,6 +85,7 @@ private:
 	int m_iPagesIndex;
 	int m_iPagesCount;
 	int m_iCurrentPage;
+	bool m_bIsSettingsConfig;
 };
 
 CMenuScriptConfigPage::CMenuScriptConfigPage() : CMenuItemsHolder()
@@ -125,7 +126,7 @@ void CMenuScriptConfigPage::Save()
 }
 
 CMenuScriptConfig::CMenuScriptConfig() : CMenuFramework( "ScriptConfig" ),
-	m_pVars(), m_szConfig(), m_iVarsCount(), m_iPagesIndex(), m_iPagesCount(), m_iCurrentPage()
+	m_pVars(), m_szConfig(), m_iVarsCount(), m_iPagesIndex(), m_iPagesCount(), m_iCurrentPage(), m_bIsSettingsConfig()
 {
 
 }
@@ -174,14 +175,42 @@ void CMenuScriptConfig::ListItemCvarGetCb(CMenuBaseItem *pSelf, void *pExtra)
 	}
 }
 
-static void ScriptGenericCvarGetCb( CMenuBaseItem *pSelf, void *pExtra )
+static void ScriptCvarGetNoSync( CMenuBaseItem *pSelf, void *pExtra )
 {
 	CMenuEditable *self = (CMenuEditable*)pSelf;
 	scrvardef_t *var = (scrvardef_t*)pExtra;
 
 	if( !var ) return;
 
-	// Prefer actual engine cvar value when available; otherwise, fallback to script value
+	switch( var->type )
+	{
+	case T_BOOL:
+	{
+		self->SetOriginalValue( ( var->value[0] == '1' ) ? 1.0f : 0.0f );
+		break;
+	}
+	case T_NUMBER:
+	{
+		self->SetOriginalValue( (float)atof( var->value ) );
+		break;
+	}
+	case T_STRING:
+	{
+		self->SetOriginalString( var->value );
+		break;
+	}
+	default:
+		break;
+	}
+}
+
+static void ScriptCvarGetSync( CMenuBaseItem *pSelf, void *pExtra )
+{
+	CMenuEditable *self = (CMenuEditable*)pSelf;
+	scrvardef_t *var = (scrvardef_t*)pExtra;
+
+	if( !var ) return;
+
 	switch( var->type )
 	{
 	case T_BOOL:
@@ -214,7 +243,41 @@ static void ScriptGenericCvarGetCb( CMenuBaseItem *pSelf, void *pExtra )
 	}
 }
 
-static void ScriptGenericCvarWriteCb( CMenuBaseItem *pSelf, void *pExtra )
+static void ScriptCvarWriteNoSync( CMenuBaseItem *pSelf, void *pExtra )
+{
+	CMenuEditable *self = (CMenuEditable*)pSelf;
+	scrvardef_t *var = (scrvardef_t*)pExtra;
+
+	if( !var ) return;
+
+	switch( var->type )
+	{
+	case T_BOOL:
+	{
+		int v = (int)self->CvarValue();
+		Q_strncpy( var->value, v ? "1" : "0", sizeof( var->value ) );
+		break;
+	}
+	case T_NUMBER:
+	{
+		char tmp[64];
+		snprintf( tmp, sizeof( tmp ), "%g", self->CvarValue() );
+		Q_strncpy( var->value, tmp, sizeof( var->value ) );
+		break;
+	}
+	case T_STRING:
+	{
+		const char *s = self->CvarString();
+		if( s ) Q_strncpy( var->value, s, sizeof( var->value ) );
+		else var->value[0] = '\0';
+		break;
+	}
+	default:
+		break;
+	}
+}
+
+static void ScriptCvarWriteSync( CMenuBaseItem *pSelf, void *pExtra )
 {
 	CMenuEditable *self = (CMenuEditable*)pSelf;
 	scrvardef_t *var = (scrvardef_t*)pExtra;
@@ -295,9 +358,9 @@ void CMenuScriptConfig::_Init( void )
 			editable = checkbox;
 			cvarType = CMenuEditable::CVAR_VALUE;
 
-			editable->onCvarGet = ScriptGenericCvarGetCb;
+			editable->onCvarGet = m_bIsSettingsConfig ? ScriptCvarGetNoSync : ScriptCvarGetSync;
 			editable->onCvarGet.pExtra = (void*)var;
-			editable->onCvarWrite = ScriptGenericCvarWriteCb;
+			editable->onCvarWrite = m_bIsSettingsConfig ? ScriptCvarWriteNoSync : ScriptCvarWriteSync;
 			editable->onCvarWrite.pExtra = (void*)var;
 			break;
 		}
@@ -317,9 +380,9 @@ void CMenuScriptConfig::_Init( void )
 
 			cvarType = CMenuEditable::CVAR_VALUE;
 
-			editable->onCvarGet = ScriptGenericCvarGetCb;
+			editable->onCvarGet = m_bIsSettingsConfig ? ScriptCvarGetNoSync : ScriptCvarGetSync;
 			editable->onCvarGet.pExtra = (void*)var;
-			editable->onCvarWrite = ScriptGenericCvarWriteCb;
+			editable->onCvarWrite = m_bIsSettingsConfig ? ScriptCvarWriteNoSync : ScriptCvarWriteSync;
 			editable->onCvarWrite.pExtra = (void*)var;
 			break;
 		}
@@ -330,9 +393,9 @@ void CMenuScriptConfig::_Init( void )
 			editable = field;
 			cvarType = CMenuEditable::CVAR_STRING;
 
-			editable->onCvarGet = ScriptGenericCvarGetCb;
+			editable->onCvarGet = m_bIsSettingsConfig ? ScriptCvarGetNoSync : ScriptCvarGetSync;
 			editable->onCvarGet.pExtra = (void*)var;
-			editable->onCvarWrite = ScriptGenericCvarWriteCb;
+			editable->onCvarWrite = m_bIsSettingsConfig ? ScriptCvarWriteNoSync : ScriptCvarWriteSync;
 			editable->onCvarWrite.pExtra = (void*)var;
 			break;
 		}
@@ -386,12 +449,13 @@ void CMenuScriptConfig::_Init( void )
 	pageSelector.onChanged = VoidCb( &CMenuScriptConfig::FlipMenu );
 }
 
-void CMenuScriptConfig::SetScriptConfig(const char *path, bool earlyInit)
+void CMenuScriptConfig::SetScriptConfig(const char *path, bool bIsSettings, bool earlyInit)
 {
 	if( m_szConfig && m_pVars && !stricmp( m_szConfig, path ) )
 		return; // do nothing
 
 	m_szConfig = path;
+	m_bIsSettingsConfig = bIsSettings;
 
 	if( m_pVars )
 		CSCR_FreeList( m_pVars );
@@ -432,8 +496,8 @@ void UI_AdvUserOptions_Menu()
 void UI_LoadScriptConfig()
 {
 	// yes, create cvars if needed
-	menu_serveroptions->SetScriptConfig( "settings.scr", true );
-	menu_useroptions->SetScriptConfig( "user.scr", true );
+	menu_serveroptions->SetScriptConfig( "settings.scr", true, true );
+	menu_useroptions->SetScriptConfig( "user.scr", false, true );
 }
 
 void UI_SaveScriptConfig()


### PR DESCRIPTION
`ScriptCvarGetNoSync` and `ScriptCvarWriteNoSync` used for UI display, saving to file, and applying values on server start, applied to the **settings.scr** file.

`ScriptCvarGetSync` and `ScriptCvarWriteSync` used for immediate cvar application, saving to file, and values sync between UI and engine, applied to the **user.scr** file.

**It fixes broken reading of settings.scr variables in advanced server options (values were synchronized with the engine instead of being read from the file), introduced in:** https://github.com/FWGS/mainui_cpp/commit/5a2ea8ba9406d08186ac340d1e34242a43c86ad8