### PR TITLE
ColorUtils: Fix Utils.h include case and remove unnecessary port.h include

### DIFF
--- a/ColorUtils.h
+++ b/ColorUtils.h
@@ -18,8 +18,7 @@ GNU General Public License for more details.
 #define COLORUTILS_H
 
 #include <math.h>
-#include "port.h"
-#include "utils.h"
+#include "Utils.h"
 
 namespace ColorUtils
 {


### PR DESCRIPTION
Should fix the build for: https://github.com/FWGS/xash3d-fwgs/pull/2598