### PR TITLE
dictgen: add explicit UTF-8 encoding when opening files

### DIFF
--- a/dictgen.py
+++ b/dictgen.py
@@ -48,7 +48,7 @@ def process_file(name):
 	trans = []
 
 	# TODO: dumb! It can't find multilines
-	with open(name, "r") as f:
+	with open(name, "r", encoding='utf-8') as f:
 		for line in f.readlines():
 			trans += re.findall(TRANSLATABLE_PATTERN, line)
 


### PR DESCRIPTION
Fix script behavior on Windows when a Windows code page (e.g. 1251, 1252) is used instead of UTF-8.