### PR TITLE
controls: Table: fix headerSize width calculation by removing an extra multiplier

### DIFF
--- a/controls/Table.cpp
+++ b/controls/Table.cpp
@@ -106,7 +106,7 @@ void CMenuTable::VidInit()
 	}
 
 	// calculate header size(position is table position)
-	headerSize.w = m_scSize.w - arrow.w + iStrokeWidth * 2;
+	headerSize.w = m_scSize.w - arrow.w + iStrokeWidth;
 
 	// box is lower than header
 	boxPos.x = m_scPos.x;


### PR DESCRIPTION
Fixes the table row selection width to prevent it from overlapping the scrollbar.

### Before
<img width="747" height="71" alt="header1" src="https://github.com/user-attachments/assets/642d484a-291e-4065-80c1-0476e91b64f1" />

### After
<img width="743" height="67" alt="header2" src="https://github.com/user-attachments/assets/398735ef-cd5d-4446-b7c0-71e0ce52e86b" />
