### PR TITLE
ServerBrowser: fix: prevent duplicate favorite server entries on refresh

### DIFF
--- a/menus/ServerBrowser.cpp
+++ b/menus/ServerBrowser.cpp
@@ -887,7 +887,7 @@ void CMenuServerBrowser::QueryServerList( const CUtlVector<favlist_entry_t> &lis
 
 		FOR_EACH_VEC( gameListModel.servers, j )
 		{
-			if( !EngFuncs::NET_CompareAdr( &gameListModel.servers, &adr ))
+			if( !EngFuncs::NET_CompareAdr( &gameListModel.servers[j].adr, &adr ))
 			{
 				found = true;
 				break;


### PR DESCRIPTION
The code incorrectly passed a pointer to the entire ``gameListModel.servers`` array instead of the specific server address, ``gameListModel.servers[j].adr``.

This caused servers in the Favorites list to be duplicated each time the Refresh button was clicked.

<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/ba8ec3ca-c390-4770-87ed-a3126626c823" />
