### PR TITLE
LoadGame: localize known save types (quick/autosave)

### DIFF
--- a/menus/LoadGame.cpp
+++ b/menus/LoadGame.cpp
@@ -276,7 +276,15 @@ void CMenuSavesListModel::Update( void )
 			Q_strncpy( s, title, sizeof( s ));
 
 			if( type )
-				snprintf( save.comment, sizeof( save.comment ), "[%.16s]%s", type, L( s ));
+			{
+				// Localize known save-type identifiers (quick/autosave). Otherwise, fall back to original behavior.
+				if( !stricmp( type, "quick" ))
+					snprintf( save.comment, sizeof( save.comment ), "%s%s", L( "GameUI_QuickSave" ), L( s ));
+				else if( !stricmp( type, "autosave" ))
+					snprintf( save.comment, sizeof( save.comment ), "%s%s", L( "GameUI_AutoSave" ), L( s ));
+				else
+					snprintf( save.comment, sizeof( save.comment ), "[%.16s]%s", type, L( s ));
+			}
 			else Q_strncpy( save.comment, L( s ), sizeof( save.comment ));
 		}
 		else


### PR DESCRIPTION
### Before
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/2545a991-0c88-4f4b-8ff0-4a1955fe158d" />


### After
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/3a6d0ad0-e5ea-4741-a0f0-8833b802f46b" />
