### PR TITLE
Fix WinAPI font rendering for non-ASCII glyphs

### DIFF
--- a/font/BaseFontBackend.cpp
+++ b/font/BaseFontBackend.cpp
@@ -555,8 +555,8 @@ int CBaseFont::DrawCharacter(int ch, Point pt, int charH, const unsigned int col
 #define CACHED_FONT_IDENT \
 	(('T'<<24)+('F'<<16)+('I'<<8)+'U') // little-endian "UIFT"
 
-// Version 2. Font blur has been changed, force font regeneration
-#define CACHED_FONT_VERSION 2
+// Version 3. WinAPI font rendering behavior changed, force font regeneration
+#define CACHED_FONT_VERSION 3
 
 struct char_data_t
 {

--- a/font/BaseFontBackend.h
+++ b/font/BaseFontBackend.h
@@ -40,7 +40,7 @@ struct charRange_t
 	{
 		if( sequence )
 			return size;
-		return chMax - chMin;
+		return chMax - chMin + 1;
 	}
 
 	int Character( size_t pos )

--- a/font/WinAPIFont.cpp
+++ b/font/WinAPIFont.cpp
@@ -89,8 +89,8 @@ bool CWinAPIFont::Create( const char *name, int tall, int weight, int blur, floa
 	::SelectObject( m_hDC, m_hFont );
 	::SetTextAlign( m_hDC, TA_LEFT | TA_TOP | TA_UPDATECP );
 
-	::TEXTMETRIC tm = { 0 };
-	if( !GetTextMetrics( m_hDC, &tm ) )
+	::TEXTMETRICW tm = { 0 };
+	if( !GetTextMetricsW( m_hDC, &tm ) )
 	{
 		Con_Printf( "Couldn't create windows font %s: GetTextMetrics failed\n", name );
 		return false;
@@ -139,13 +139,13 @@ void CWinAPIFont::GetCharRGBA( int ch, Point pt, Size sz, unsigned char *rgba, S
 	// try and get the glyph directly
 
 	::SelectObject( m_hDC, m_hFont );
-	bytesNeeded = ::GetGlyphOutline( m_hDC, ch, GGO_GRAY8_BITMAP, &glyphMetrics, 0, NULL, &mat2 );
+	bytesNeeded = ::GetGlyphOutlineW( m_hDC, ch, GGO_GRAY8_BITMAP, &glyphMetrics, 0, NULL, &mat2 );
 	
 	if( bytesNeeded > 0 )
 	{
 		// take it
 		unsigned char *lpbuf = ( unsigned char * )_alloca( bytesNeeded );
-		::GetGlyphOutline( m_hDC, ch, GGO_GRAY8_BITMAP, &glyphMetrics, bytesNeeded, lpbuf, &mat2 );
+		::GetGlyphOutlineW( m_hDC, ch, GGO_GRAY8_BITMAP, &glyphMetrics, bytesNeeded, lpbuf, &mat2 );
 		
 		// rows are on DWORD boundaries
 		wide = glyphMetrics.gmBlackBoxX;


### PR DESCRIPTION
Fix Windows MainUI font rendering for Cyrillic and other non-ASCII characters by using explicit Unicode GDI calls (fixes https://github.com/FWGS/xash3d-fwgs/issues/2644).
Fix an off-by-one error that excluded the last character from each character range: `0x007E` (`~`, ASCII), `0x00FF` (`ÿ`, Latin-1 Supplement), and `0x017F` (`ſ`, Latin Extended-A).